### PR TITLE
Add Chrome trace profiling

### DIFF
--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -29,6 +29,7 @@ log.workspace = true
 mpi.workspace = true
 tokio.workspace = true
 warp.workspace = true
+pprof = { version = "0.13", features = ["flamegraph", "protobuf"] }
 
 [[bin]]
 name = "dev-setup"

--- a/bin/src/main.rs
+++ b/bin/src/main.rs
@@ -6,6 +6,7 @@ use std::{
 
 use circuit::Circuit;
 use clap::Parser;
+use pprof::ProfilerGuardBuilder;
 use gkr::{
     BN254ConfigMIMC5KZG, BN254ConfigSha2Hyrax, BN254ConfigSha2Raw, GF2ExtConfigSha2Orion,
     GF2ExtConfigSha2Raw, Goldilocksx8ConfigSha2Orion, Goldilocksx8ConfigSha2Raw,
@@ -47,6 +48,10 @@ struct Args {
     /// number of thread
     #[arg(short, long, default_value_t = 1)]
     threads: u64,
+
+    /// Enable profiling to generate flamegraph.svg and trace.json
+    #[arg(long, default_value_t = false)]
+    trace: bool,
 }
 
 fn main() {
@@ -136,6 +141,17 @@ where
         .collect::<Vec<_>>();
 
     let pack_size = <Cfg::FieldConfig as FieldEngine>::get_field_pack_size();
+
+    let profiler_guard = if args.trace {
+        Some(
+            ProfilerGuardBuilder::default()
+                .frequency(1000)
+                .build()
+                .unwrap(),
+        )
+    } else {
+        None
+    };
 
     // load circuit
     let mut circuit_template = match args.circuit.as_str() {
@@ -291,6 +307,17 @@ where
         let throughput =
             total_proof_cnt as f64 / duration.as_secs_f64() * (mpi_config.world_size() as f64);
         println!("{}-bench: throughput: {} hashes/s", i, throughput.round());
+    }
+
+    if let Some(guard) = profiler_guard {
+        if let Ok(report) = guard.report().build() {
+            if let Ok(file) = std::fs::File::create("flamegraph.svg") {
+                let _ = report.flamegraph(file);
+            }
+            if let Ok(file) = std::fs::File::create("trace.json") {
+                let _ = report.chrometracing(file);
+            }
+        }
     }
 }
 

--- a/readme.md
+++ b/readme.md
@@ -136,6 +136,15 @@ RUSTFLAGS="-C target-cpu=native" cargo run --bin expander-exec --release --featu
 
 Note that enabling the `profile` feature will slightly reduce the overall performance so it is recommended not to enable it when benchmarking.
 
+### Flamegraph and Chrome Trace
+You can record a profiling run that generates both a `flamegraph.svg` and a `trace.json` compatible with Chrome Trace by passing the `--trace` flag to the `gkr` binary:
+
+```sh
+RUSTFLAGS="-C target-cpu=native" cargo run --release --bin gkr -- --trace -f fr -t 16
+```
+
+The files will be created in the current directory after the benchmark completes.
+
 ## How to contribute?
 
 Thank you for your interest in contributing to our project! We seek contributors with a robust background in cryptography and programming, aiming to improve and expand the capabilities of our proof generation system.


### PR DESCRIPTION
## Summary
- add `pprof` to `bin` crate
- support `--trace` flag in `bin/src/main.rs`
- write flamegraph and Chrome trace when tracing is enabled
- document how to run with `--trace`

## Testing
- `cargo check -p bin` *(fails: could not download required toolchain)*